### PR TITLE
add processing timeout

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -23,6 +23,7 @@ type ComponentSpec struct {
 	component.ClientSpec    `json:",inline"`
 	component.RequeueSpec   `json:",inline"`
 	component.RetrySpec     `json:",inline"`
+	component.TimeoutSpec   `json:",inline"`
 	// +required
 	SourceRef    SourceReference                `json:"sourceRef"`
 	Revision     string                         `json:"revision,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -81,6 +81,7 @@ func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 	in.ClientSpec.DeepCopyInto(&out.ClientSpec)
 	in.RequeueSpec.DeepCopyInto(&out.RequeueSpec)
 	in.RetrySpec.DeepCopyInto(&out.RetrySpec)
+	in.TimeoutSpec.DeepCopyInto(&out.TimeoutSpec)
 	in.SourceRef.DeepCopyInto(&out.SourceRef)
 	if in.Values != nil {
 		in, out := &in.Values, &out.Values

--- a/crds/core.cs.sap.com_components.yaml
+++ b/crds/core.cs.sap.com_components.yaml
@@ -187,6 +187,9 @@ spec:
                     - name
                     type: object
                 type: object
+              timeout:
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
               values:
                 x-kubernetes-preserve-unknown-fields: true
               valuesFrom:
@@ -338,6 +341,11 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
+              processingDigest:
+                type: string
+              processingSince:
+                format: date-time
+                type: string
               state:
                 description: Component state. Can be one of 'Ready', 'Pending', 'Processing',
                   'DeletionPending', 'Deleting', 'Error'.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fluxcd/source-controller/api v1.3.0
 	github.com/getsops/sops/v3 v3.8.1
 	github.com/pkg/errors v0.9.1
-	github.com/sap/component-operator-runtime v0.3.32
+	github.com/sap/component-operator-runtime v0.3.34
 	github.com/sap/go-generics v0.2.13
 	k8s.io/apiextensions-apiserver v0.30.2
 	k8s.io/apimachinery v0.30.2

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
-github.com/sap/component-operator-runtime v0.3.32 h1:V7zuyLoNeZYytpY45GtdmzdW8YmGonDH+gcKU3k/tZk=
-github.com/sap/component-operator-runtime v0.3.32/go.mod h1:nvtWaSpVyb+2d+AWhHPjyr187/yrt9ssVH7DxMyGkrU=
+github.com/sap/component-operator-runtime v0.3.34 h1:ewqs6mAQxYlBGsXffBkBWcwpZTPr6YL12NNBakQ/sn0=
+github.com/sap/component-operator-runtime v0.3.34/go.mod h1:nvtWaSpVyb+2d+AWhHPjyr187/yrt9ssVH7DxMyGkrU=
 github.com/sap/go-generics v0.2.13 h1:rSED7M+S7aw/9AomJq7omjgZtwvoixHsfVbOiCWs4cM=
 github.com/sap/go-generics v0.2.13/go.mod h1:G6v+AnJtKlUGB/ATd+zdUcosvBdUSyrHg7/kn5UKgx8=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=


### PR DESCRIPTION
Add new spec field `timeout`, leveraging the changes introduced in https://github.com/SAP/component-operator-runtime/releases/tag/v0.3.34.