### PR TITLE
post-read hook must not be run in deletion case

### DIFF
--- a/pkg/operator/hooks.go
+++ b/pkg/operator/hooks.go
@@ -31,6 +31,10 @@ import (
 
 func makeFuncPostRead() component.HookFunc[*operatorv1alpha1.Component] {
 	return func(ctx context.Context, clnt client.Client, component *operatorv1alpha1.Component) error {
+		if !component.DeletionTimestamp.IsZero() {
+			return nil
+		}
+
 		sourceRef := &component.Spec.SourceRef
 		sourceRefUrl := ""
 		sourceRefRevision := ""


### PR DESCRIPTION
the post-read logic should not be executed in the delete case. Otherwise, referenced are required to exist until the deletion is completed, which would be an unnecessary complication for users.
Because loading the source references (which is basically what happens in the post-read hook) is not required in the deletion logic.