### PR TITLE
leverage source digest instead resp. besides source revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Here, components are understood as sets of Kubernetes resources (such as deploym
 
 Thus, components are similar to flux kustomizations, but have some important advantages:
 - They use the [component-operator-runtime](https://github.com/sap/component-operator-runtime) framework to render and deploy dependent objects; therefore the manifest source can be any input that is understood by component-operator-runtime's [KustomizeGenerator](https://sap.github.io/component-operator-runtime/docs/generators/kustomize/) or [HelmGenerator](https://sap.github.io/component-operator-runtime/docs/generators/helm/). In particular, go-templatized kustomizations are allowed; check the [component-operator-runtime documentation](https://sap.github.io/component-operator-runtime/docs) for details.
-- It is possible to pin components to a specific source revision through the `spec.revision` field.
+- It is possible to pin components to a specific source revision or digest through the `spec.revision` and `spec.digest` fields, respectively.
 - Dependencies (as specified in `spec.dependencies`) are not only honored at creation/update, but also on deletion.
 
 A sample component could look like this:
@@ -111,12 +111,12 @@ sourceRef:
 
 Cross-namespace references are allowed; if namespace is not provided, the source will be assumed to exist in the component's namespace.
 
-### Source revision
+### Source revision and digest
 
-It is possible to pin a `Component` resource to a specific revision of the source artifact by setting `spec.revision`.
-Pinning means that the component will remain in a `Pending` state, until the used source object's revision matches the the value
-specified in `spec.revision`. More precisely, in case of flux source resources, the field refers to `status.artifact.revision` of the flux object.
-It should be noted that a revision mismatch in the above sense never blocks the deletion of the component.
+It is possible to pin a `Component` resource to a specific revision or digest of the source artifact by setting `spec.revision` and `spec.digest`, respectively.
+Pinning means that the component will remain in a `Pending` state, until the used source object's revision or digest matches the the value
+specified in `spec.revision` or `spec.digest`. In case of flux sources, revision and digest refer to `status.artifact.revision` and `status.artifact.digest` of the according flux object.
+It should be noted that a revision or digest mismatch in the above sense never blocks the deletion of the component.
 
 ### Source path
 

--- a/crds/core.cs.sap.com_components.yaml
+++ b/crds/core.cs.sap.com_components.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: components.core.cs.sap.com
 spec:
   group: core.cs.sap.com
@@ -81,6 +81,8 @@ spec:
                   - name
                   type: object
                 type: array
+              digest:
+                type: string
               kubeConfig:
                 description: KubeConfigSpec defines a reference to a kubeconfig.
                 properties:
@@ -143,7 +145,7 @@ spec:
               sourceRef:
                 description: |-
                   SourceReference models the source of the templates used to render the dependent resources.
-                  Exactly one of the options must be provided. Before accessing the Url() or Revision() methods,
+                  Exactly one of the options must be provided. Before accessing the Url(), Digest() or Revision() methods,
                   a SourceReference must be loaded by calling Init().
                 properties:
                   fluxBucket:
@@ -189,16 +191,21 @@ spec:
                   httpRepository:
                     description: Reference to a generic http repository.
                     properties:
+                      digestHeader:
+                        description: |-
+                          Name of the header containing the digest of the source artifact. The returned header value can be any format, but must uniquely identify the
+                          content of the source artifact. Defaults to the ETag header.
+                        type: string
                       revisionHeader:
                         description: |-
-                          Name of the header containing the revision of the source artifact. The returned header value can be any format, but must uniquely identify the
-                          content of the source artifact. If unspecified, the ETag header will be used.
+                          Name of the header containing the revision of the source artifact. The returned header value can be any format.
+                          Defaults to the header specified in DigestHeader.
                         type: string
                       url:
                         description: |-
-                          URL of the source. Authentication is currently not supported. The operator will make HEAD requests to retrieve the revision and a potentially
-                          redirected actual location of the source artifact. Redirects will be followed as long as the response does not
-                          contain the specified revision header.
+                          URL of the source. Authentication is currently not supported. The operator will make HEAD requests to retrieve the digest/revision
+                          and a potentially redirected actual location of the source artifact. Redirects will be followed as long as the response does not
+                          contain the specified digest header.
                         type: string
                     type: object
                 type: object
@@ -346,7 +353,11 @@ spec:
               lastAppliedAt:
                 format: date-time
                 type: string
+              lastAppliedDigest:
+                type: string
               lastAppliedRevision:
+                type: string
+              lastAttemptedDigest:
                 type: string
               lastAttemptedRevision:
                 type: string

--- a/crds/core.cs.sap.com_components.yaml
+++ b/crds/core.cs.sap.com_components.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: components.core.cs.sap.com
 spec:
   group: core.cs.sap.com

--- a/internal/generator/factory.go
+++ b/internal/generator/factory.go
@@ -56,6 +56,7 @@ func init() {
 	}()
 }
 
+// note: id must uniquely identify the decrypted content downloaded from url/path
 func GetGenerator(id string, url string, path string, clnt client.Client, decryptionProvider string, decryptionKeys map[string][]byte) (manifests.Generator, error) {
 	mutex.Lock()
 	defer mutex.Unlock()

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -41,7 +41,8 @@ func (g *Generator) Generate(ctx context.Context, namespace string, name string,
 	spec := parameters.(*operatorv1alpha1.ComponentSpec)
 
 	url := spec.SourceRef.Url()
-	revision := spec.SourceRef.Revision()
+	digest := spec.SourceRef.Digest()
+	path := spec.Path
 
 	var decryptionProvider string
 	var decryptionKeys map[string][]byte
@@ -50,7 +51,9 @@ func (g *Generator) Generate(ctx context.Context, namespace string, name string,
 		decryptionKeys = spec.Decryption.SecretRef.Data()
 	}
 
-	generator, err := GetGenerator(url+"\n"+revision+"\n"+spec.Path, url, spec.Path, g.client, decryptionProvider, decryptionKeys)
+	// note: url is actually not needed in the generator id, digest is enough to identify the content
+	id := url + "\n" + digest + "\n" + path + "\n" + decryptionProvider + "\n" + calculateDigest(decryptionKeys)
+	generator, err := GetGenerator(id, url, path, g.client, decryptionProvider, decryptionKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/generator/util.go
+++ b/internal/generator/util.go
@@ -5,6 +5,12 @@ SPDX-License-Identifier: Apache-2.0
 
 package generator
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
 func deepMerge(x map[string]any, y map[string]any) {
 	for k := range y {
 		if _, ok := x[k]; ok {
@@ -27,4 +33,17 @@ func shallowMerge[T any](x map[string]T, y map[string]T) {
 	for k := range y {
 		x[k] = y[k]
 	}
+}
+
+func sha256hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func calculateDigest(values ...any) string {
+	raw, err := json.Marshal(values)
+	if err != nil {
+		panic(err)
+	}
+	return sha256hex(raw)
 }

--- a/internal/sources/flux/cache.go
+++ b/internal/sources/flux/cache.go
@@ -130,6 +130,10 @@ func (h *sourceHandler) Update(ctx context.Context, e event.TypedUpdateEvent[cli
 	if artifact == nil {
 		return
 	}
+	newDigest := artifact.Digest
+	if newDigest == "" {
+		return
+	}
 	newRevision := artifact.Revision
 	if newRevision == "" {
 		return
@@ -140,11 +144,11 @@ func (h *sourceHandler) Update(ctx context.Context, e event.TypedUpdateEvent[cli
 		h.indexKey: client.ObjectKeyFromObject(e.ObjectNew).String(),
 	}); err != nil {
 		// TODO
-		// log.Error(err, "failed to list objects for source revision change")
+		// log.Error(err, "failed to list components")
 		return
 	}
 	for _, c := range componentList.Items {
-		if c.IsReady() && c.Status.LastAttemptedRevision == newRevision {
+		if c.IsReady() && c.Status.LastAttemptedDigest == newDigest && c.Status.LastAttemptedRevision == newRevision {
 			continue
 		}
 		q.Add(reconcile.Request{NamespacedName: apitypes.NamespacedName{

--- a/internal/sources/httprepository/checker.go
+++ b/internal/sources/httprepository/checker.go
@@ -53,13 +53,16 @@ func (c *Checker) Start(ctx context.Context) error {
 		}
 		for _, component := range componentList.Items {
 			if component.Spec.SourceRef.HttpRepository != nil {
-				_, revision, err := GetUrlAndRevision(component.Spec.SourceRef.HttpRepository.Url, component.Spec.SourceRef.HttpRepository.RevisionHeader)
+				url := component.Spec.SourceRef.HttpRepository.Url
+				digestHeader := component.Spec.SourceRef.HttpRepository.DigestHeader
+				revisionHeader := component.Spec.SourceRef.HttpRepository.RevisionHeader
+				_, digest, revision, err := GetArtifact(url, digestHeader, revisionHeader)
 				if err == nil {
-					if revision != component.Status.LastAttemptedRevision {
+					if digest != component.Status.LastAttemptedDigest || revision != component.Status.LastAttemptedRevision {
 						c.reconciler.Trigger(component.Namespace, component.Name)
 					}
 				} else {
-					c.logger.Error(err, "error fetching revision from http repository", "url", component.Spec.SourceRef.HttpRepository.Url, "revisionHeader", component.Spec.SourceRef.HttpRepository.RevisionHeader)
+					c.logger.Error(err, "error fetching revision from http repository", "url", url, "digestHeader", digestHeader, "revisionHeader", revisionHeader)
 				}
 			}
 		}

--- a/internal/sources/httprepository/util.go
+++ b/internal/sources/httprepository/util.go
@@ -10,14 +10,17 @@ import (
 	"net/http"
 )
 
-func GetUrlAndRevision(url string, revisionHeader string) (string, string, error) {
+func GetArtifact(url string, digestHeader string, revisionHeader string) (string, string, string, error) {
+	if digestHeader == "" {
+		digestHeader = "etag"
+	}
 	if revisionHeader == "" {
-		revisionHeader = "etag"
+		revisionHeader = digestHeader
 	}
 
 	httpClient := http.Client{
 		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
-			if req.Response.Header.Get(revisionHeader) != "" {
+			if req.Response.Header.Get(digestHeader) != "" {
 				return http.ErrUseLastResponse
 			}
 			return nil
@@ -25,25 +28,29 @@ func GetUrlAndRevision(url string, revisionHeader string) (string, string, error
 	}
 	resp, err := httpClient.Head(url)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	switch {
 	case resp.StatusCode >= 400:
-		return "", "", fmt.Errorf("error calling source reference URL: %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return "", "", "", fmt.Errorf("error calling source reference URL: %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
 	case resp.StatusCode >= 300:
 		location, err := resp.Location()
 		if err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 		url = location.String()
 	case resp.StatusCode >= 200:
 		url = resp.Request.URL.String()
 	default:
-		return "", "", fmt.Errorf("referenced source not ready")
+		return "", "", "", fmt.Errorf("referenced source not ready")
+	}
+	digest := resp.Header.Get(digestHeader)
+	if digest == "" {
+		return "", "", "", fmt.Errorf("missing digest on source reference")
 	}
 	revision := resp.Header.Get(revisionHeader)
 	if revision == "" {
-		return "", "", fmt.Errorf("missing revision on source reference")
+		return "", "", "", fmt.Errorf("missing revision on source reference")
 	}
-	return url, revision, nil
+	return url, digest, revision, nil
 }

--- a/pkg/operator/hooks.go
+++ b/pkg/operator/hooks.go
@@ -37,16 +37,18 @@ func makeFuncPostRead() component.HookFunc[*operatorv1alpha1.Component] {
 
 		sourceRef := &component.Spec.SourceRef
 		sourceRefUrl := ""
+		sourceRefDigest := ""
 		sourceRefRevision := ""
 
 		switch {
 		case sourceRef.HttpRepository != nil:
-			url, revision, err := httprepository.GetUrlAndRevision(component.Spec.SourceRef.HttpRepository.Url, component.Spec.SourceRef.HttpRepository.RevisionHeader)
+			url, digest, revision, err := httprepository.GetArtifact(component.Spec.SourceRef.HttpRepository.Url, component.Spec.SourceRef.HttpRepository.DigestHeader, component.Spec.SourceRef.HttpRepository.RevisionHeader)
 			if err != nil {
 				return err
 			}
 
 			sourceRefUrl = url
+			sourceRefDigest = digest
 			sourceRefRevision = revision
 		case sourceRef.FluxGitRepository != nil, sourceRef.FluxOciRepository != nil, sourceRef.FluxBucket != nil, sourceRef.FluxHelmChart != nil:
 			var sourceName operatorv1alpha1.NamespacedName
@@ -80,14 +82,29 @@ func makeFuncPostRead() component.HookFunc[*operatorv1alpha1.Component] {
 			}
 
 			artifact := source.GetArtifact()
+
+			if artifact.URL == "" {
+				return componentoperatorruntimetypes.NewRetriableError(fmt.Errorf("source not ready (missing URL)"), ref(10*time.Second))
+			}
+			if artifact.Digest == "" {
+				return componentoperatorruntimetypes.NewRetriableError(fmt.Errorf("source not ready (missing digest)"), ref(10*time.Second))
+			}
+			if artifact.Revision == "" {
+				return componentoperatorruntimetypes.NewRetriableError(fmt.Errorf("source not ready (missing revision)"), ref(10*time.Second))
+			}
+
 			sourceRefUrl = artifact.URL
+			sourceRefDigest = artifact.Digest
 			sourceRefRevision = artifact.Revision
 		default:
 			return fmt.Errorf("unable to get source; one of httpRepository, fluxGitRepository, fluxOciRepository, fluxBucket, fluxHelmChart must be defined")
 		}
 
-		sourceRef.Init(sourceRefUrl, sourceRefRevision)
+		sourceRef.Init(sourceRefUrl, sourceRefDigest, sourceRefRevision)
 
+		if component.Spec.Digest != "" && sourceRefDigest != component.Spec.Digest {
+			return componentoperatorruntimetypes.NewRetriableError(fmt.Errorf("source digest (%s) does not match specified digest (%s)", sourceRefDigest, component.Spec.Digest), ref(10*time.Second))
+		}
 		if component.Spec.Revision != "" && sourceRefRevision != component.Spec.Revision {
 			return componentoperatorruntimetypes.NewRetriableError(fmt.Errorf("source revision (%s) does not match specified revision (%s)", sourceRefRevision, component.Spec.Revision), ref(10*time.Second))
 		}
@@ -97,8 +114,9 @@ func makeFuncPostRead() component.HookFunc[*operatorv1alpha1.Component] {
 
 func makeFuncPreReconcile(cache cache.Cache) component.HookFunc[*operatorv1alpha1.Component] {
 	return func(ctx context.Context, clnt client.Client, component *operatorv1alpha1.Component) error {
-		// note: it is crucial to set status.lastAttemptedRevision here (in pre-reconcile), since generators
+		// note: it is crucial to set status.lastAttemptedDigest and status.lastAttemptedRevision here (in pre-reconcile), since generators
 		// might fetch the component from their context, relying on the field being already updated
+		component.Status.LastAttemptedDigest = component.Spec.SourceRef.Digest()
 		component.Status.LastAttemptedRevision = component.Spec.SourceRef.Revision()
 		for _, dependency := range component.Spec.Dependencies {
 			c := &operatorv1alpha1.Component{}
@@ -108,7 +126,7 @@ func makeFuncPreReconcile(cache cache.Cache) component.HookFunc[*operatorv1alpha
 				}
 				return err
 			}
-			if c.Spec.SourceRef.Equals(&component.Spec.SourceRef) && (c.Status.LastAttemptedRevision == "" || c.Status.LastAttemptedRevision != component.Status.LastAttemptedRevision) {
+			if c.Spec.SourceRef.Equals(&component.Spec.SourceRef) && (c.Status.LastAttemptedDigest == "" || c.Status.LastAttemptedDigest != component.Status.LastAttemptedDigest || c.Status.LastAttemptedRevision == "" || c.Status.LastAttemptedRevision != component.Status.LastAttemptedRevision) {
 				return componentoperatorruntimetypes.NewRetriableError(fmt.Errorf("dependent component %s not synced", dependency), nil)
 			}
 			if !c.IsReady() {
@@ -121,6 +139,7 @@ func makeFuncPreReconcile(cache cache.Cache) component.HookFunc[*operatorv1alpha
 
 func makeFuncPostReconcile() component.HookFunc[*operatorv1alpha1.Component] {
 	return func(ctx context.Context, clnt client.Client, component *operatorv1alpha1.Component) error {
+		component.Status.LastAppliedDigest = component.Status.LastAttemptedDigest
 		component.Status.LastAppliedRevision = component.Status.LastAttemptedRevision
 		return nil
 	}


### PR DESCRIPTION
A referenced source has a revision (a version id in the source system, that is, some kind of release, helm chart version, git sha) and a digest (that is a unique content identifier). Revision and digest are in in principle independent of each other; the same content may be published under a different revision, or an existing revision may be moved (e.g. in case of a helm chart) to a different content.

As of now, only the source revision is used
(1) to identify source content
(2) to pin components to a specific version of the source

This PR changes that. In all cases of type (1) the digest or even both digest and revision will be used to identify content.
In all cases of type (2) the user can choose to pin the component to digest or revision or both.