### PR TITLE
Bump component operator runtime

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -270,11 +270,9 @@ func (c *Component) GetStatus() *component.Status {
 func (c *Component) GetEventAnnotations(previousState component.State, componentDigest string) map[string]string {
 	annotations := make(map[string]string)
 	annotations[fmt.Sprintf("%s/revision", GroupVersion.Group)] = c.Status.LastAttemptedRevision
+	annotations[fmt.Sprintf("%s/%s", GroupVersion.Group, fluxeventv1beta1.MetaTokenKey)] = fmt.Sprintf("%s:%s", c.UID, componentDigest)
 	if previousState != component.StateProcessing || c.Status.State != component.StateReady {
 		annotations[fmt.Sprintf("%s/%s", GroupVersion.Group, fluxeventv1beta1.MetaCommitStatusKey)] = fluxeventv1beta1.MetaCommitStatusUpdateValue
-	}
-	if componentDigest != "" {
-		annotations[fmt.Sprintf("%s/%s", GroupVersion.Group, fluxeventv1beta1.MetaTokenKey)] = componentDigest
 	}
 	return annotations
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/getsops/sops/v3 v3.9.2
 	github.com/go-logr/logr v1.4.2
 	github.com/pkg/errors v0.9.1
-	github.com/sap/component-operator-runtime v0.3.78
+	github.com/sap/component-operator-runtime v0.3.79
 	github.com/sap/go-generics v0.2.28
 	k8s.io/apiextensions-apiserver v0.32.2
 	k8s.io/apimachinery v0.32.2

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
-github.com/sap/component-operator-runtime v0.3.78 h1:XXEgEugDBadTQIqCwp1szf11NOyntDr7TdJ3xcaSyxg=
-github.com/sap/component-operator-runtime v0.3.78/go.mod h1:p5AYoMahLwYS/3VKh1dZZ3yzqhWKQX4NZCzOJ2yKsbI=
+github.com/sap/component-operator-runtime v0.3.79 h1:yf+g1lWCsIShVEdxYejqx6hUPcprO5psOb6yCwolOLI=
+github.com/sap/component-operator-runtime v0.3.79/go.mod h1:p5AYoMahLwYS/3VKh1dZZ3yzqhWKQX4NZCzOJ2yKsbI=
 github.com/sap/go-generics v0.2.28 h1:Aad95UymJE95s/bpiNemM2FXNWkVMdGkcMrfXizRaIk=
 github.com/sap/go-generics v0.2.28/go.mod h1:yNx3OnTozQTSIXZo/nulcBjew3dYzoB1LfIuRCf1dYE=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=


### PR DESCRIPTION
Bump component-operator-runtime.

In addition, we include the component's `metadata.uid` into the flux `token` event annotation, in order to avoid events being dropped if a component get's identically recreated. Not sure why flux does not consider the `uid` here (https://github.com/fluxcd/notification-controller/blob/2763e548bd16298f13739108f7635a6438731b96/internal/server/event_server.go#L223); the default client-go event recorder **does** use the `uid` to idenfify events...