### PR TITLE
add kustomize based post-renderers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25.6 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -23,6 +23,7 @@ import (
 	fluxsourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 
 	"github.com/sap/component-operator-runtime/pkg/component"
+	"github.com/sap/component-operator-runtime/pkg/manifests"
 	componentoperatorruntimetypes "github.com/sap/component-operator-runtime/pkg/types"
 
 	"github.com/sap/component-operator/internal/object"
@@ -248,11 +249,16 @@ type Decryption struct {
 // The according variables can provided inline by Substitute or as secrets by SubstituteFrom.
 // If a variable name appears in more than one secret, then later values have precedence,
 // and inline values have precedence over those defined through secrets.
+// Furthermore, kustomize patches and image replacements can be defined, which are applied after the variable substitution.
 type PostBuild struct {
 	// Variables to be substituted in the renderered manifests.
 	Substitute map[string]string `json:"substitute,omitempty"`
 	// Secrets containing variables to be used for substitution.
 	SubstituteFrom []component.SecretReference `json:"substituteFrom,omitempty" notFoundPolicy:"ignoreOnDeletion"`
+	// A list of kustomize patches.
+	Patches []manifests.KustomizePatch `json:"patches,omitempty"`
+	// A list of kustomize image replacements.
+	Images []manifests.KustomizeImage `json:"images,omitempty"`
 }
 
 // Dependency models a dependency of the containing component to another Component (referenced by namespace and name).
@@ -310,7 +316,7 @@ type Artifact struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 // +genclient
 
 // Component is the Schema for the components API.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -11,6 +11,7 @@ package v1alpha1
 
 import (
 	"github.com/sap/component-operator-runtime/pkg/component"
+	"github.com/sap/component-operator-runtime/pkg/manifests"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -304,6 +305,18 @@ func (in *PostBuild) DeepCopyInto(out *PostBuild) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Patches != nil {
+		in, out := &in.Patches, &out.Patches
+		*out = make([]manifests.KustomizePatch, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.Images != nil {
+		in, out := &in.Images, &out.Images
+		*out = make([]manifests.KustomizeImage, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/crds/core.cs.sap.com_components.yaml
+++ b/crds/core.cs.sap.com_components.yaml
@@ -151,7 +151,54 @@ spec:
                   The according variables can provided inline by Substitute or as secrets by SubstituteFrom.
                   If a variable name appears in more than one secret, then later values have precedence,
                   and inline values have precedence over those defined through secrets.
+                  Furthermore, kustomize patches and image replacements can be defined, which are applied after the variable substitution.
                 properties:
+                  images:
+                    description: A list of kustomize image replacements.
+                    items:
+                      description: Kustomize image modifier specification, basically
+                        a subset of sigs.k8s.io/kustomize/api/types#Image
+                      properties:
+                        digest:
+                          type: string
+                        name:
+                          type: string
+                        newName:
+                          type: string
+                        newTag:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  patches:
+                    description: A list of kustomize patches.
+                    items:
+                      description: Kustomize patch specification, basically a subset
+                        of sigs.k8s.io/kustomize/api/types#Patch
+                      properties:
+                        patch:
+                          type: string
+                        target:
+                          description: Kustomize object selector; corresponds to sigs.k8s.io/kustomize/api/types#Selector
+                          properties:
+                            annotationSelector:
+                              type: string
+                            group:
+                              type: string
+                            kind:
+                              type: string
+                            labelSelector:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
                   substitute:
                     additionalProperties:
                       type: string

--- a/go.mod
+++ b/go.mod
@@ -1,23 +1,22 @@
 module github.com/sap/component-operator
 
-go 1.26.0
+go 1.26.2
 
 require (
 	filippo.io/age v1.3.1
-	github.com/drone/envsubst v1.0.3
 	github.com/fluxcd/pkg/apis/event v0.24.0
 	github.com/fluxcd/pkg/runtime v0.102.0
 	github.com/fluxcd/source-controller/api v1.8.0
 	github.com/getsops/sops/v3 v3.12.1
 	github.com/go-logr/logr v1.4.3
 	github.com/pkg/errors v0.9.1
-	github.com/sap/component-operator-runtime v0.3.132
-	github.com/sap/go-generics v0.2.53
+	github.com/sap/component-operator-runtime v0.3.142
+	github.com/sap/go-generics v0.2.57
 	k8s.io/apiextensions-apiserver v0.35.1
 	k8s.io/apimachinery v0.36.0-alpha.1
 	k8s.io/client-go v0.35.1
 	k8s.io/code-generator v0.35.1
-	sigs.k8s.io/controller-runtime v0.23.1
+	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260216173200-e4c1c38bcbdb
 	sigs.k8s.io/controller-tools v0.20.1
 	sigs.k8s.io/yaml v1.6.0
@@ -80,6 +79,7 @@ require (
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/drone/envsubst v1.0.3 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
@@ -207,7 +207,7 @@ require (
 	k8s.io/api v0.35.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
-	k8s.io/kube-aggregator v0.35.0 // indirect
+	k8s.io/kube-aggregator v0.35.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570 // indirect
 	sigs.k8s.io/cli-utils v0.37.2 // indirect
@@ -215,5 +215,5 @@ require (
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -429,10 +429,10 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
-github.com/sap/component-operator-runtime v0.3.132 h1:5M127i8JzRf71bUHF1RtfrFDj3T8HfabiOYHm6mwtEc=
-github.com/sap/component-operator-runtime v0.3.132/go.mod h1:ipqNU5Uw/CsI42A4P4zdcQyp6Vp/KBhZmJ1+0kKjCBA=
-github.com/sap/go-generics v0.2.53 h1:C5MltWIx6MxpgPxQJa2eupGm3Jim4jIfwm/2KOT1BQM=
-github.com/sap/go-generics v0.2.53/go.mod h1:xqWmp3jVLGNTmTuPjwdWgNk11pzi0zarA1iqV0om24c=
+github.com/sap/component-operator-runtime v0.3.142 h1:LJlLO+3DGNvhlu0gAjU0cgQgTVvUScCgFIx9cMtp+jg=
+github.com/sap/component-operator-runtime v0.3.142/go.mod h1:tMO/LejPPPNT8dO33yGHSyht0RrLsu+tKugefRx4v3E=
+github.com/sap/go-generics v0.2.57 h1:BTINpYYC3oNo8rhRCVwmQZ8wmsoLm6JzJqkE6zkQi80=
+github.com/sap/go-generics v0.2.57/go.mod h1:9HF4GCtwEy7ioJTz/QZCY4CoNjHJWYsNB30ALIR3un4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
@@ -697,8 +697,8 @@ k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b h1:gMplByicHV/TJBizHd9aVEsTYo
 k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b/go.mod h1:CgujABENc3KuTrcsdpGmrrASjtQsWCT7R99mEV4U/fM=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
-k8s.io/kube-aggregator v0.35.0 h1:FBtbuRFA7Ohe2QKirFZcJf8rgimC8oSaNiCi4pdU5xw=
-k8s.io/kube-aggregator v0.35.0/go.mod h1:vKBRpQUfDryb7udwUwF3eCSvv3AJNgHtL4PGl6PqAg8=
+k8s.io/kube-aggregator v0.35.1 h1:LN+btMJ3yp7biqVgT/0LF6SKIKLyfPU0R+JJ1mycs2I=
+k8s.io/kube-aggregator v0.35.1/go.mod h1:HQSjPQfOFRzcv7biQ7jV3cEfKHG+bczpLCfh4QfvxZU=
 k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 h1:HhDfevmPS+OalTjQRKbTHppRIz01AWi8s45TMXStgYY=
 k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20260108192941-914a6e750570 h1:JT4W8lsdrGENg9W+YwwdLJxklIuKWdRm+BC+xt33FOY=
@@ -707,8 +707,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/cli-utils v0.37.2 h1:GOfKw5RV2HDQZDJlru5KkfLO1tbxqMoyn1IYUxqBpNg=
 sigs.k8s.io/cli-utils v0.37.2/go.mod h1:V+IZZr4UoGj7gMJXklWBg6t5xbdThFBcpj4MrZuCYco=
-sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
-sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
+sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
+sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260216173200-e4c1c38bcbdb h1:idmKgblo0x0z4OGzrva4fg+z02b5FnU/gr5MS21/Kuo=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260216173200-e4c1c38bcbdb/go.mod h1:IlbgWQkCYbpbkygXxnd/sLJWL9WQk9NvvVhkJCm5P7Q=
 sigs.k8s.io/controller-tools v0.20.1 h1:gkfMt9YodI0K85oT8rVi80NTXO/kDmabKR5Ajn5GYxs=
@@ -721,7 +721,7 @@ sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7
 sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.3.2 h1:kwVWMx5yS1CrnFWA/2QHyRVJ8jM6dBA80uLmm0wJkk8=
-sigs.k8s.io/structured-merge-diff/v6 v6.3.2/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
+sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
+sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/drone/envsubst"
 	"github.com/sap/go-generics/maps"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,45 +69,36 @@ func (g *Generator) Generate(ctx context.Context, namespace string, name string,
 		deepMerge(values, v)
 	}
 
+	if spec.PostBuild != nil {
+		transformableGenerator := manifests.NewGenerator(generator)
+		if len(spec.PostBuild.Substitute) > 0 || len(spec.PostBuild.SubstituteFrom) > 0 {
+			substitutions := make(map[string]string)
+			for _, ref := range spec.PostBuild.SubstituteFrom {
+				shallowMerge(substitutions, maps.Collect(ref.Data(), func(x []byte) string { return string(x) }))
+			}
+			shallowMerge(substitutions, spec.PostBuild.Substitute)
+			transformer, err := manifests.NewSubstitutionObjectTransformer(substitutions, componentoperatorruntimetypes.SelectorFunc[client.Object](func(object client.Object) bool {
+				return object.GetAnnotations()[reconcilerName+"/disableSubstitution"] != "true"
+			}))
+			if err != nil {
+				return nil, err
+			}
+			transformableGenerator.WithObjectTransformer(transformer)
+		}
+		if len(spec.PostBuild.Patches) > 0 || len(spec.PostBuild.Images) > 0 {
+			transformer, err := manifests.NewKustomizeObjectTransformer(spec.PostBuild.Patches, spec.PostBuild.Images)
+			if err != nil {
+				return nil, err
+			}
+			transformableGenerator.WithObjectTransformer(transformer)
+		}
+		generator = transformableGenerator
+	}
+
 	objects, err := generator.Generate(ctx, namespace, name, componentoperatorruntimetypes.UnstructurableMap(values))
 	if err != nil {
 		return nil, err
 	}
 
-	substitutions := make(map[string]string)
-	if spec.PostBuild != nil {
-		for _, ref := range spec.PostBuild.SubstituteFrom {
-			shallowMerge(substitutions, maps.Collect(ref.Data(), func(x []byte) string { return string(x) }))
-		}
-		shallowMerge(substitutions, spec.PostBuild.Substitute)
-	}
-
-	if len(substitutions) == 0 {
-		return objects, nil
-	}
-
-	var substitutedObjects []client.Object
-	for _, object := range objects {
-		if object.GetAnnotations()[reconcilerName+"/disableSubstitution"] == "true" {
-			continue
-		}
-		rawObject, err := kyaml.Marshal(object)
-		if err != nil {
-			return nil, err
-		}
-		stringObject := string(rawObject)
-		stringObject, err = envsubst.Eval(stringObject, func(s string) string {
-			return substitutions[s]
-		})
-		if err != nil {
-			return nil, err
-		}
-		rawObject = []byte(stringObject)
-		if err := kyaml.Unmarshal(rawObject, object); err != nil {
-			return nil, err
-		}
-		substitutedObjects = append(substitutedObjects, object)
-	}
-
-	return substitutedObjects, nil
+	return objects, nil
 }


### PR DESCRIPTION
## Enhancements

Add kustomize-like post-renderers (`patches` and `images`) to `spec.postBuild`:

```go
type PostBuild struct {
	// Variables to be substituted in the renderered manifests.
	Substitute map[string]string `json:"substitute,omitempty"`
	// Secrets containing variables to be used for substitution.
	SubstituteFrom []component.SecretReference `json:"substituteFrom,omitempty" notFoundPolicy:"ignoreOnDeletion"`
	// A list of kustomize patches.
	Patches []manifests.KustomizePatch `json:"patches,omitempty"`
	// A list of kustomize image replacements.
	Images []manifests.KustomizeImage `json:"images,omitempty"`
}
```