### PR TITLE
add component suspend

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -36,6 +36,7 @@ type ComponentSpec struct {
 	component.PlacementSpec     `json:",inline"`
 	component.ClientSpec        `json:",inline"`
 	component.ImpersonationSpec `json:",inline"`
+	component.SuspensionSpec    `json:",inline"`
 	component.RequeueSpec       `json:",inline"`
 	component.RetrySpec         `json:",inline"`
 	component.TimeoutSpec       `json:",inline"`
@@ -316,6 +317,7 @@ type Artifact struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].reason`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 // +genclient
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -96,6 +96,7 @@ func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 	out.PlacementSpec = in.PlacementSpec
 	in.ClientSpec.DeepCopyInto(&out.ClientSpec)
 	out.ImpersonationSpec = in.ImpersonationSpec
+	out.SuspensionSpec = in.SuspensionSpec
 	in.RequeueSpec.DeepCopyInto(&out.RequeueSpec)
 	in.RetrySpec.DeepCopyInto(&out.RetrySpec)
 	in.TimeoutSpec.DeepCopyInto(&out.TimeoutSpec)

--- a/crds/core.cs.sap.com_components.yaml
+++ b/crds/core.cs.sap.com_components.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.state
       name: State
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -312,6 +315,8 @@ spec:
                     || !has(self.httpRepository) && !has(self.fluxGitRepository) &&
                     !has(self.fluxOciRepository) && !has(self.fluxBucket) && has(self.fluxHelmChart)
               sticky:
+                type: boolean
+              suspend:
                 type: boolean
               timeout:
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$


### PR DESCRIPTION
Add the option `spec.suspend` to suspend the reconciliation of a component. If set, the component goes into `Pending` state (with `Ready` reason `Suspended`). Note that, even if suspended, a component will be deleted as usual.